### PR TITLE
Fix get_term_link() usage; other bugs

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -528,16 +528,19 @@ function get_pubs($catid=null, $pubid=null, $sort='latest') {
 	$args = array('post_type' => 'pubedition', 'numberposts' => -1);
 	// By publication id args
 	if ($pubid !== null) {
-		$pub = get_term_by('id', $pubid, 'publications');
-		$args = array_merge($args, array(
-			'taxonomy' => 'publications',
-			'term'     => $pub->name,
-		));
+		$args = array_merge( $args, array(
+			'tax_query' => array(
+				array(
+					'taxonomy' => 'publications',
+					'terms'    => $pubid,
+				)
+			)
+		) );
 	}
 	// By category id args
 	elseif ($catid !== null) {
 		$args = array_merge($args, array(
-			'cat' => $catid,
+			'category' => $catid,
 		));
 	}
 	// Sorting args
@@ -657,7 +660,7 @@ function display_pubs($pubs, $reference_pubeditions=false, $styling='default') {
 						$publication = get_term_by('slug', $publication, 'publications');
 						$publication_name = $publication->name;
 						$pubdate 		  = date('M j, Y', strtotime($post->post_date));
-						$publink 		  = get_term_link($publication_name, 'publications');
+						$publink 		  = get_term_link($publication, 'publications');
 
 						$firstletter = strtoupper(substr($publication_name, 0, 1));
 						if ($firstletter != $currentletter) { ?>
@@ -709,15 +712,15 @@ function display_pubs($pubs, $reference_pubeditions=false, $styling='default') {
 				$pubedition_link  = get_permalink($post->ID);
 				if ($reference_pubeditions == false) {
 					$publication_name = $publication->name;
-					$publication_link = get_term_link($publication_name, 'publications');
+					$publication_link = get_term_link($publication, 'publications');
 					$publink = $publication_link;
 				}
 				else {
 					$publication_name = $post->post_title;
-					$publication_term_name = $publication->name;
-					$publication_link = get_term_link($publication_term_name, 'publications');
+					$publication_link = get_term_link($publication, 'publications');
 					$publink = $pubedition_link;
 				}
+
 				$pubdate 		  = date('M j, Y', strtotime($post->post_date));
 				$issuulink 		  = get_post_meta($post->ID, 'pubedition_embed', TRUE);
 

--- a/search.php
+++ b/search.php
@@ -8,13 +8,13 @@
 ?>
 <?php get_header();?>
 	<div class="page-content row" id="search-results">
-		
+
 		<div class="results span12">
 			<h2>Search results for "<?=htmlentities($_GET['s'])?>"</h2>
 			<?php get_search_form()?>
-			
+
 			<?php if(count($results['items'])):?>
-			
+
 			<ul class="result-list">
 				<?php foreach($results['items'] as $result):?>
 				<li class="item">
@@ -34,36 +34,36 @@
 				</li>
 				<?php endforeach;?>
 			</ul>
-			
+
 			<?php if($start + $limit < $results['number']):?>
 			<a class="button more" href="./?s=<?=$_GET['s']?>&amp;start=<?=$start + $limit?>">More Results</a>
 			<?php endif;?>
-			
+
 			<?php else:?>
-				
+
 			<p>No results found for "<?=htmlentities($_GET['s'])?>".</p>
-			
+
 			<?php endif;?>
 		</div>
-		
+
 	</div>
 <?php get_footer();?>
 <?php else:?>
 	<?php get_header();?>
 	<div class="page-content row" id="search-results">
-		
+
 		<div class="results span12">
 			<h2>Search results for "<?=htmlentities($_GET['s'])?>"</h2>
 			<?php get_search_form()?>
-			
+
 			<?php if(have_posts()):?>
 			<ul class="result-list">
     			<?php while(have_posts()): the_post();?>
     			<li class="item">
 					<?php
-					$pubs 	 = get_the_terms($post->ID, 'publications'); 
+					$pubs 	 = get_the_terms($post->ID, 'publications');
 					foreach ($pubs as $pub) {
-						$publink = get_term_link($pub->slug, 'publications');
+						$publink = get_term_link($pub, 'publications');
 						$pubname = $pub->name;
 					}
 					?>
@@ -71,12 +71,12 @@
 					<p><strong>Published:</strong> <?php print get_the_date('M d, Y'); ?></p>
 					<p><strong>An edition of:</strong> <a target="_blank" href="<?=$publink?>"><?=$pubname?></a></p>
 					<p><strong>Found in:</strong> <?php the_category(', '); ?></p>
-    				
+
     			</li>
 			    <?php endwhile;?>
 			</ul>
 			<?php else:?>
-				
+
 			<p>No results found for "<?=htmlentities($_GET['s'])?>".</p>
 			<?php endif;?>
 		</div>

--- a/single.php
+++ b/single.php
@@ -16,7 +16,7 @@ else {
 		<script type="text/javascript">
 			var _sf_startpt = (new Date()).getTime();
 			<?php if(GA_ACCOUNT):?>
-			
+
 			var GA_ACCOUNT = '<?=GA_ACCOUNT?>';
 			var _gaq = _gaq || [];
 			_gaq.push(['_setAccount', GA_ACCOUNT]);
@@ -25,36 +25,46 @@ else {
 			_gaq.push(['_trackPageview']);
 			<?php endif;?>
 			<?php if(CB_UID):?>
-	
+
 			var CB_UID = '<?=CB_UID?>';
 			var CB_DOMAIN = '<?=CB_DOMAIN?>';
 			<?php endif?>
 		</script>
-		<?php endif;?>		
+		<?php endif;?>
 	</head>
-	
+
 	<body class="<?=get_post_type($post->ID)?>">
-	
-		<?php 
+
+		<?php
 		//Display message stating a newer issue is available, with link to new issue, if this is not the newest post under its taxonomy term
 		$terms	= wp_get_post_terms($post->ID, 'publications');
 		foreach ($terms as $term) {
-			$termid   = $term->term_id; 
-			$termlink = get_term_link( $term->name, 'publications' );
+			$termid   = $term->term_id;
+			$termlink = get_term_link( $term, 'publications' );
 		}
-		$latestEdition = get_posts(array('post_type' => 'pubedition', 'taxonomy' => 'publications', 'term' => $terms[0]->name, 'post_status' => 'publish', 'numberposts' => 1));
-		$latestEdition = $latestEdition[0];
-		if ($post->ID !== $latestEdition->ID) {
+		$latest_edition = get_posts( array(
+			'post_type' => 'pubedition',
+			'tax_query' => array(
+				array(
+					'taxonomy' => 'publications',
+					'terms' => $terms[0],
+				)
+			),
+			'post_status' => 'publish',
+			'numberposts' => 1
+		) );
+		$latest_edition = $latest_edition[0];
+		if ($post->ID !== $latest_edition->ID) {
 			print '<div class="alert in fade">
 						<a class="close" data-dismiss="alert" href="#">×</a>
 						<strong>Note: </strong> A newer version of this publication is available!  <a class="btn btn-small" href="'.$termlink.'" style="margin-left: 6px;">View Updated Publication</a>
 					</div>';
 		}
-		
+
 		?>
 
 	<?php embed_issuu($post->ID); ?>
-	
+
 	</body>
 	<?="\n".footer_()."\n"?>
 </html>

--- a/taxonomy-publications.php
+++ b/taxonomy-publications.php
@@ -1,12 +1,23 @@
 <?php
-	$publication = $wp_query->queried_object;
-	$latestEdition = get_posts(array('post_type' => 'pubedition', 'taxonomy' => 'publications', 'term' => $publication->name, 'order' => 'DESC', 'post_status' => 'publish', 'numberposts' => 1));
-	$latestEdition = $latestEdition[0];
-?>
-	
-<?php if ($_GET['issuu-data'] == 'docID') {
+$publication = $wp_query->queried_object;
+$latest_edition = get_posts( array(
+	'post_type' => 'pubedition',
+	'tax_query' => array(
+		array(
+			'taxonomy' => 'publications',
+			'terms'    => $publication->term_id
+		)
+	),
+	'order' => 'DESC',
+	'post_status' => 'publish',
+	'numberposts' => 1
+) );
+$latest_edition = $latest_edition[0];
+
+
+if ($_GET['issuu-data'] == 'docID') {
 	$issuudata = array();
-	$issuudata['docID'] = get_pubedition_docid($latestEdition->ID);
+	$issuudata['docID'] = get_pubedition_docid($latest_edition->ID);
 	print json_encode($issuudata);
 }
 else {
@@ -22,7 +33,7 @@ else {
 		<script type="text/javascript">
 			var _sf_startpt = (new Date()).getTime();
 			<?php if(GA_ACCOUNT):?>
-			
+
 			var GA_ACCOUNT = '<?=GA_ACCOUNT?>';
 			var _gaq = _gaq || [];
 			_gaq.push(['_setAccount', GA_ACCOUNT]);
@@ -31,31 +42,32 @@ else {
 			_gaq.push(['_trackPageview']);
 			<?php endif;?>
 			<?php if(CB_UID):?>
-	
+
 			var CB_UID = '<?=CB_UID?>';
 			var CB_DOMAIN = '<?=CB_DOMAIN?>';
 			<?php endif?>
 		</script>
 		<?php endif;?>
 	</head>
-	
-	
-	
+
+
+
 	<body class="<?=get_post_type($post->ID)?>">
 		<?php
 		if (is_only_edition($post->ID) == false) {
-			$terms		 = wp_get_post_terms($post->ID, 'publications'); 
-			$archivelink = get_permalink(get_page_by_title('Archive')->ID).'?publication='.$terms[0]->slug; 
+			$terms		 = wp_get_post_terms($post->ID, 'publications');
+			$term        = $terms[0];
+			$archivelink = get_permalink( get_page_by_title( 'Archive' ) ) .'?publication='. $term->slug;
 		?>
 		<div class="alert in fade">
 			<a class="close" data-dismiss="alert" href="#">×</a>
-			You're viewing the newest edition of this publication.  
-			<a class="btn btn-small" href="<?=$archivelink?>" style="margin-left: 6px;">View Archives (<?=get_pubedition_count_by_publication($terms[0]->term_id)?>)</a>
-		</div>		
+			You're viewing the newest edition of this publication.
+			<a class="btn btn-small" href="<?=$archivelink?>" style="margin-left: 6px;">View Archives (<?=get_pubedition_count_by_publication($term->term_id)?>)</a>
+		</div>
 		<?php } ?>
-		
-		<?php embed_issuu($latestEdition->ID); ?>
-	
+
+		<?php embed_issuu($latest_edition->ID); ?>
+
 	</body>
 	<?="\n".footer_()."\n"?>
 </html>


### PR DESCRIPTION
Fixes some incorrect usage of get_term_link() (pass in the term object, instead of the formatted name) and improper setup of tax_query's in get_posts() calls.  Fixes an issue we encountered before the break where a publication term name was updated to include forward slash and caused a WSOD on the frontend (yuck).

Probably want to add ?w=1 to the PR url to filter out the excess whitespace changes in the diff.