### PR TITLE
Update provided embed codes in "Embed Code" modals

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -724,7 +724,12 @@ function display_pubs($pubs, $reference_pubeditions=false, $styling='default') {
 
 				$pubdate          = date('M j, Y', strtotime($post->post_date));
 				$issuu_link       = get_post_meta( $post->ID, 'pubedition_issuu_url', true );
-				$issuu_embed_code = wp_oembed_get( $issuu_link );
+				// Using wp_oembed_get( $issuu_link ) here would be ideal, except that
+				// wordpress doesn't cache the results, making the page load really slow with
+				// each external request.
+				// To avoid cache headaches, just insert the markup manually for the embed
+				// code buttons.
+				$issuu_embed_code = '<div data-url="'. $issuu_link.' " style="width: 500px; height: 325px;" class="issuuembed"></div><script type="text/javascript" src="//e.issuu.com/embed.js" async="true"></script>';
 
 			?>
 

--- a/functions.php
+++ b/functions.php
@@ -723,7 +723,7 @@ function display_pubs($pubs, $reference_pubeditions=false, $styling='default') {
 				}
 
 				$pubdate          = date('M j, Y', strtotime($post->post_date));
-				$issuu_link       = get_post_meta( $post->ID, 'pubedition_issuu_url', true );
+				$issuu_link       = get_pubedition_issuu_url( $post->ID );
 				// Using wp_oembed_get( $issuu_link ) here would be ideal, except that
 				// wordpress doesn't cache the results, making the page load really slow with
 				// each external request.

--- a/functions.php
+++ b/functions.php
@@ -718,8 +718,9 @@ function display_pubs($pubs, $reference_pubeditions=false, $styling='default') {
 					$publication_link = get_term_link($publication_term_name, 'publications');
 					$publink = $pubedition_link;
 				}
-				$pubdate 		  = date('M j, Y', strtotime($post->post_date));
-				$issuulink 		  = get_post_meta($post->ID, 'pubedition_embed', TRUE);
+				$pubdate          = date('M j, Y', strtotime($post->post_date));
+				$issuu_link       = get_post_meta( $post->ID, 'pubedition_issuu_url', true );
+				$issuu_embed_code = wp_oembed_get( $issuu_link );
 
 			?>
 
@@ -770,9 +771,13 @@ function display_pubs($pubs, $reference_pubeditions=false, $styling='default') {
 										<p><strong>Instructions:</strong></p>
 										<p>Copy/paste the code below wherever you want the publication* to display on your site.</p>
 										<div class="well">
-										<?php if ($docID) { ?>
-											<textarea name="pubembed" class="pubembed"><div><object style="width:420px;height:273px"><param name="movie" value="//static.issuu.com/webembed/viewers/style1/v2/IssuuReader.swf?mode=mini&amp;backgroundColor=%23222222&amp;documentId=<?=$docID?>" /><param name="allowfullscreen" value="true"/><param name="menu" value="false"/><param name="wmode" value="transparent"/><embed src="//static.issuu.com/webembed/viewers/style1/v2/IssuuReader.swf" type="application/x-shockwave-flash" allowfullscreen="true" menu="false" wmode="transparent" style="width:420px;height:273px" flashvars="mode=mini&amp;backgroundColor=%23222222&amp;documentId=<?=$docID?>" /></object></div></textarea>
-										<?php } else { ?>Embed code not available.<?php } ?>
+										<?php if ( $issuu_embed_code ): ?>
+											<textarea name="pubembed" class="pubembed">
+												<?php echo $issuu_embed_code; ?>
+											</textarea>
+										<?php else: ?>
+											Embed code not available.
+										<?php endif; ?>
 										</div>
 										<p><small>*If a new edition of this publication is released, you'll need to update your embed code to display the latest version.</small></p>
 									</div>


### PR DESCRIPTION
Updates the provided code snippet when you click on an "Embed Code" button for a publication to use Issuu's latest oembed snippet, instead of the old flash player.

Note, we add the markup manually (instead of fetching it dynamically, like we do when we display individual pubeditions) due to WordPress' crummy caching of oembed responses.  There's an easy-to-understand rundown of the situation in this comment on another plugin:  https://github.com/documentcloud/wordpress-documentcloud/issues/20#issuecomment-97478302
But in a nutshell, it's more performant and easier to just add the embed markup manually.